### PR TITLE
create dac_volume

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,11 +106,7 @@ Usage Example
 	# use headphones
 	# helper function for default settings
 	dac.headphone_output = True
-	dac.headphone_volume = -20  # dB
-	# or use speaker
-	# helper function for default settings
-	# dac.speaker_output = True
-	# dac.speaker_volume = -15 # dB
+	dac.dac_volume = -20  # dB
 
 	audio = audiobusio.I2SOut(board.I2S_BCLK, board.I2S_WS, board.I2S_DIN)
 

--- a/examples/tlv320_simpletest.py
+++ b/examples/tlv320_simpletest.py
@@ -20,7 +20,7 @@ dac.configure_clocks(sample_rate=44100, bit_depth=16)
 
 # use headphones
 dac.headphone_output = True
-dac.headphone_volume = -15  # dB
+dac.dac_volume = -10  # dB
 # or use speaker
 # dac.speaker_output = True
 # dac.speaker_volume = -20 # dB


### PR DESCRIPTION
in investigating https://github.com/adafruit/Adafruit_CircuitPython_TLV320/issues/5, headphone_volume() has minimal effect. setting dac_volume is effective with the headphone output 