### PR TITLE
set speaker and headphone volume levels during init.

### DIFF
--- a/adafruit_tlv320.py
+++ b/adafruit_tlv320.py
@@ -877,6 +877,8 @@ class TLV320DAC3100:
             right_path=DAC_PATH_NORMAL,
         )
         self._page0._set_dac_volume_control(False, False, VOL_INDEPENDENT)
+        self.speaker_volume = -15
+        self.headphone_volume = -15
 
     # Basic properties and methods
 


### PR DESCRIPTION
I noticed by default that `speaker_volume` after DAC init is `63.1579` which is outside the range specified by the `speaker_volume` property. 

I don't think this setting is actually taking effect because the sound output from the speaker is still fairly quiet. 

However I think it's best to explicitly set both of these to a value we know is safe for the speakers that are stocked in the shop. Both to avoid any potential damage to hardware, and to make it less confusing if anyone happens to check the value of and assumes that the value it returns will be valid for passing back to it to be set.