### PR TITLE
Overhaul Volume Control Implementation

### DIFF
--- a/adafruit_tlv320.py
+++ b/adafruit_tlv320.py
@@ -15,6 +15,11 @@ Implementation Notes
 
 **Hardware:**
 
+* `Adafruit TLV320DAC3100 - I2S DAC <https://www.adafruit.com/product/6309>`_
+
+* `Adafruit Fruit Jam <https://www.adafruit.com/product/6200>`_
+
+
 * The TLV320DAC chip has moderately complex onboard audio filtering, routing,
   and amplification capability. Each of the signal chains for speaker, headphone
   left, and headphone right start with the DAC, then they go through a mixer
@@ -122,56 +127,92 @@ DATA_LEN_24 = const(0b10)  # 24 bits
 DATA_LEN_32 = const(0b11)  # 32 bits
 
 # GPIO1 pin mode options
-GPIO1_DISABLED = const(0b0000)  # GPIO1 disabled (input and output buffers powered down)
-GPIO1_INPUT_MODE = const(0b0001)  # Input mode (secondary BCLK/WCLK/DIN input or ClockGen)
-GPIO1_GPI = const(0b0010)  # General-purpose input
-GPIO1_GPO = const(0b0011)  # General-purpose output
-GPIO1_CLKOUT = const(0b0100)  # CLKOUT output
-GPIO1_INT1 = const(0b0101)  # INT1 output
-GPIO1_INT2 = const(0b0110)  # INT2 output
-GPIO1_BCLK_OUT = const(0b1000)  # Secondary BCLK output for codec interface
-GPIO1_WCLK_OUT = const(0b1001)  # Secondary WCLK output for codec interface
+#: GPIO1 pin mode options: GPIO1 disabled (input and output buffers powered down)
+GPIO1_DISABLED = const(0b0000)
+#: GPIO1 pin mode options: Input mode (secondary BCLK/WCLK/DIN input or ClockGen)
+GPIO1_INPUT_MODE = const(0b0001)
+#: GPIO1 pin mode options: General-purpose input
+GPIO1_GPI = const(0b0010)
+#: GPIO1 pin mode options: General-purpose output
+GPIO1_GPO = const(0b0011)
+#: GPIO1 pin mode options: CLKOUT output
+GPIO1_CLKOUT = const(0b0100)
+#: GPIO1 pin mode options: INT1 output
+GPIO1_INT1 = const(0b0101)
+#: GPIO1 pin mode options: INT2 output
+GPIO1_INT2 = const(0b0110)
+#: GPIO1 pin mode options: Secondary BCLK output for codec interface
+GPIO1_BCLK_OUT = const(0b1000)
+#: GPIO1 pin mode options: Secondary WCLK output for codec interface
+GPIO1_WCLK_OUT = const(0b1001)
 
 # DAC channel data path options
-DAC_PATH_OFF = const(0b00)  # DAC data path off
-DAC_PATH_NORMAL = const(0b01)  # Normal path (L->L or R->R)
-DAC_PATH_SWAPPED = const(0b10)  # Swapped path (R->L or L->R)
-DAC_PATH_MIXED = const(0b11)  # Mixed L+R path
+#: DAC channel data path option: DAC data path off
+DAC_PATH_OFF = const(0b00)
+#: DAC channel data path option: Normal path (L->L or R->R)
+DAC_PATH_NORMAL = const(0b01)
+#: DAC channel data path option: Swapped path (R->L or L->R)
+DAC_PATH_SWAPPED = const(0b10)
+#: DAC channel data path option: Mixed L+R path
+DAC_PATH_MIXED = const(0b11)
 
 # DAC volume control soft stepping options
-VOLUME_STEP_1SAMPLE = const(0b00)  # One step per sample
-VOLUME_STEP_2SAMPLE = const(0b01)  # One step per two samples
-VOLUME_STEP_DISABLED = const(0b10)  # Soft stepping disabled
+#: DAC volume control soft stepping option: One step per sample
+VOLUME_STEP_1SAMPLE = const(0b00)
+#: DAC volume control soft stepping option: One step per two samples
+VOLUME_STEP_2SAMPLE = const(0b01)
+#: DAC volume control soft stepping option: Soft stepping disabled
+VOLUME_STEP_DISABLED = const(0b10)
 
 # DAC volume control configuration options
-VOL_INDEPENDENT = const(0b00)  # Left and right channels independent
-VOL_LEFT_TO_RIGHT = const(0b01)  # Left follows right volume
-VOL_RIGHT_TO_LEFT = const(0b10)  # Right follows left volume
+#: DAC volume control configuration option: Left and right channels independent
+VOL_INDEPENDENT = const(0b00)
+#: DAC volume control configuration option: Left follows right volume
+VOL_LEFT_TO_RIGHT = const(0b01)
+#: DAC volume control configuration option: Right follows left volume
+VOL_RIGHT_TO_LEFT = const(0b10)
 
 # DAC output routing options
-DAC_ROUTE_NONE = const(0b00)  # DAC not routed
-DAC_ROUTE_MIXER = const(0b01)  # DAC routed to mixer amplifier
-DAC_ROUTE_HP = const(0b10)  # DAC routed directly to HP driver
+#: DAC output routing option: DAC not routed
+DAC_ROUTE_NONE = const(0b00)
+#: DAC output routing option: DAC routed to mixer amplifier
+DAC_ROUTE_MIXER = const(0b01)
+#: DAC output routing option: DAC routed directly to HP driver
+DAC_ROUTE_HP = const(0b10)
 
-# Headphone common mode voltage settings
-HP_COMMON_1_35V = const(0b00)  # Common-mode voltage 1.35V
-HP_COMMON_1_50V = const(0b01)  # Common-mode voltage 1.50V
-HP_COMMON_1_65V = const(0b10)  # Common-mode voltage 1.65V
-HP_COMMON_1_80V = const(0b11)  # Common-mode voltage 1.80V
+# Headphone common mode voltage options
+#: Headphone common mode voltage option: Common-mode voltage 1.35V
+HP_COMMON_1_35V = const(0b00)
+#: Headphone common mode voltage option: Common-mode voltage 1.50V
+HP_COMMON_1_50V = const(0b01)
+#: Headphone common mode voltage option: Common-mode voltage 1.65V
+HP_COMMON_1_65V = const(0b10)
+#: Headphone common mode voltage option: Common-mode voltage 1.80V
+HP_COMMON_1_80V = const(0b11)
 
 # Headset detection debounce time options
-DEBOUNCE_16MS = const(0b000)  # 16ms debounce (2ms clock)
-DEBOUNCE_32MS = const(0b001)  # 32ms debounce (4ms clock)
-DEBOUNCE_64MS = const(0b010)  # 64ms debounce (8ms clock)
-DEBOUNCE_128MS = const(0b011)  # 128ms debounce (16ms clock)
-DEBOUNCE_256MS = const(0b100)  # 256ms debounce (32ms clock)
-DEBOUNCE_512MS = const(0b101)  # 512ms debounce (64ms clock)
+#: Headset detection debounce time option: 16ms debounce (2ms clock)
+DEBOUNCE_16MS = const(0b000)
+#: Headset detection debounce time option: 32ms debounce (4ms clock)
+DEBOUNCE_32MS = const(0b001)
+#: Headset detection debounce time option: 64ms debounce (8ms clock)
+DEBOUNCE_64MS = const(0b010)
+#: Headset detection debounce time option: 128ms debounce (16ms clock)
+DEBOUNCE_128MS = const(0b011)
+#: Headset detection debounce time option: 256ms debounce (32ms clock)
+DEBOUNCE_256MS = const(0b100)
+#: Headset detection debounce time option: 512ms debounce (64ms clock)
+DEBOUNCE_512MS = const(0b101)
 
 # Button press debounce time options
-BTN_DEBOUNCE_0MS = const(0b00)  # No debounce
-BTN_DEBOUNCE_8MS = const(0b01)  # 8ms debounce (1ms clock)
-BTN_DEBOUNCE_16MS = const(0b10)  # 16ms debounce (2ms clock)
-BTN_DEBOUNCE_32MS = const(0b11)  # 32ms debounce (4ms clock)
+#: Button press debounce time option: No debounce
+BTN_DEBOUNCE_0MS = const(0b00)
+#: Button press debounce time option: 8ms debounce (1ms clock)
+BTN_DEBOUNCE_8MS = const(0b01)
+#: Button press debounce time option: 16ms debounce (2ms clock)
+BTN_DEBOUNCE_16MS = const(0b10)
+#: Button press debounce time option: 32ms debounce (4ms clock)
+BTN_DEBOUNCE_32MS = const(0b11)
 
 # Lookup table for speaker_volume and headphone_volume.
 # These are from TLV320DAC3100 datasheet Table 6-24.

--- a/adafruit_tlv320.py
+++ b/adafruit_tlv320.py
@@ -8,7 +8,7 @@
 CircuitPython driver for the TLV320DAC3100 I2S DAC
 
 
-* Author(s): Liz Clark
+* Author(s): Liz Clark, Sam Blenny
 
 Implementation Notes
 --------------------
@@ -24,20 +24,19 @@ Implementation Notes
   left, and headphone right start with the DAC, then they go through a mixer
   stage, an analog volume (attenuation) stage, and finally an analog amplifier
   stage. Parameters for each stage of each signal chain can be separately set
-  with different properties.
+  with different properties. But, you can ignore most of that if you use
+  ``speaker_output = True`` or ``headphone_output = True`` to load defaults.
 
 * To understand how the different audio stages (DAC, volume, amplifier gain)
   relate to each other, it can help to look at the Functional Block Diagram in
   the TLV320DAC3100 datasheet:
   https://learn.adafruit.com/adafruit-tlv320dac3100-i2s-dac/downloads
 
-* **CAUTION**: The TLV320 speaker amplifier has enough power to easily burn out
-  small 1W speakers if you max out the volume and gain settings. To be safe,
-  start with lower levels for ``speaker_volume`` and ``speaker_gain``, then work
-  your way up to find a comfortable listening level. Similarly, for the
-  headphone output, start low with ``headphone_volume``,
-  ``headphone_left_gain``, and ``headphone_right_gain``, then increase as
-  needed.
+* **CAUTION**: The TLV320 amplifiers have enough power to easily burn out
+  small 1W speakers or drive headphones to levels that could damage your
+  hearing. To be safe, start with low volume and gain levels, then increase
+  them carefully to find a comfortable listening level. This is why the
+  default levels set by speaker_output and headphone_output are relatively low.
 
 **Software and Dependencies:**
 
@@ -45,6 +44,68 @@ Implementation Notes
   https://circuitpython.org/downloads
 
 * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
+
+Usage Examples
+--------------
+
+Fruit Jam Mini-Speaker
+^^^^^^^^^^^^^^^^^^^^^^
+
+This will start you off with a relatively low volume for the Fruit Jam's
+bundled 8-Ohm 1 Watt speaker. Your code can adjust the volume by increasing
+or decreasing ``dac_volume``. To use a higher wattage speaker that needs
+more power, you might want to increase ``speaker_volume``.
+
+::
+
+    dac = TLV320DAC3100(board.I2C())
+    dac.speaker_output = True            # set defaults for speaker
+    dac.dac_volume = dac.dac_volume + 1  # increase volume by 1 dB
+    dac.dac_volume = dac.dac_volume - 1  # decrease volume by 1 dB
+
+Low Impedance Earbuds
+^^^^^^^^^^^^^^^^^^^^^
+
+This will start you off with a relatively low volume for low impedance
+earbuds (e.g. JVC Gumy) plugged into the Fruit Jam's headphone jack. Your
+code can adjust the volume by increasing or decreasing ``dac_volume``. To
+use high impedance headphones that need more power, you might want to
+increase ``headphone_volume``.
+
+::
+
+    dac = TLV320DAC3100(board.I2C())
+    dac.speaker_output = False           # make sure speaker amp is off
+    dac.headphone_output = True          # set defaults for headphones
+    dac.dac_volume = dac.dac_volume + 1  # increase volume by 1 dB
+    dac.dac_volume = dac.dac_volume - 1  # decrease volume by 1 dB
+
+Line Level Output to Mixer
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For this one, the default headphone output volume will be way too low for
+use with a device that expects consumer line level input (-10 dBV). To fix
+that, you can increase ``dac_volume`` or ``headphone_volume``. If you want
+to experiment with different ways of setting the levels, check out the
+volume test example: `Volume test <../examples.html#volume-test>`_
+
+::
+
+    dac = TLV320DAC3100(board.I2C())
+    dac.speaker_output = False    # make sure speaker amp is off
+    dac.headphone_output = True   # set defaults for headphones (note: too low!)
+
+    # Make it louder by increasing headphone_volume. We could also use
+    # dac_volume, but doing it this way gives a better balance between
+    # the speaker signal chain and the headphone jack signal chain. (think
+    # of headphone_volume as a mixer channel's pad switch or gain trim knob
+    # and dac_volume as the main volume control fader)
+    #
+    # CAUTION: This will be *way* too loud for earbuds, please be careful!
+    dac.headphone_volume = -15.5  # default is -51.8 dB
+
+API
+---
 """
 
 import time

--- a/adafruit_tlv320.py
+++ b/adafruit_tlv320.py
@@ -2068,8 +2068,8 @@ class TLV320DAC3100:
         are intended for listening at a quiet-ish level with sensitive low
         impedance earbuds:
 
-        * dac_volume = -30
-        * headphone_volume = -42.1
+        * dac_volume = -20
+        * headphone_volume = -51.8
         * headphone_left_gain = headphone_right_gain = 0
 
         If you set this to False, the setter turns off the headphone amp.
@@ -2091,8 +2091,8 @@ class TLV320DAC3100:
         if enabled:
             self.left_dac = True
             self.right_dac = True
-            self.left_dac_channel_volume = -30
-            self.right_dac_channel_volume = -30
+            self.left_dac_channel_volume = -20
+            self.right_dac_channel_volume = -20
             self.left_dac_mute = False
             self.right_dac_mute = False
             self.left_dac_path = DAC_PATH_NORMAL
@@ -2102,7 +2102,7 @@ class TLV320DAC3100:
             self._page1._configure_headphone_driver(
                 left_powered=True, right_powered=True, common=HP_COMMON_1_65V
             )
-            self.headphone_volume = -42.1
+            self.headphone_volume = -52.8
             # NOTE: If you use DAC_ROUTE_HP here instead of DAC_ROUTE_MIXER,
             # the DAC output will bypass the headphone analog volume
             # attenuation stage and go straight into the headphone amp. That
@@ -2123,10 +2123,12 @@ class TLV320DAC3100:
     def speaker_output(self) -> bool:
         """Speaker output helper with quickstart default settings.
 
-        If you set this property to True, the setter will set:
+        If you set this property to True, the setter will set defaults intended
+        for a relatively quiet listening level using the 8Ω 1W mini speaker
+        that comes bundled with the Fruit Jam:
 
-        * dac_volume = -30
-        * speaker_volume = -42.1
+        * dac_volume = -20
+        * speaker_volume = -20.1
         * speaker_gain = 6
 
         If you set this to False, the setter turns off the speaker amp.
@@ -2144,8 +2146,8 @@ class TLV320DAC3100:
         if enabled:
             self.left_dac = True
             self.right_dac = True
-            self.left_dac_channel_volume = -30
-            self.right_dac_channel_volume = -30
+            self.left_dac_channel_volume = -20
+            self.right_dac_channel_volume = -20
             self.left_dac_mute = False
             self.right_dac_mute = False
             self.left_dac_path = DAC_PATH_NORMAL
@@ -2155,7 +2157,7 @@ class TLV320DAC3100:
             self._page1._configure_analog_inputs(
                 left_dac=DAC_ROUTE_MIXER, right_dac=DAC_ROUTE_MIXER
             )
-            self.speaker_volume = -42.1
+            self.speaker_volume = -20.1
             self.speaker_mute = False
         else:
             self._page1._set_speaker_enabled(False)
@@ -2215,7 +2217,7 @@ class TLV320DAC3100:
     @speaker_volume.setter
     def speaker_volume(self, db: float) -> None:
         # The table 6-24 lookup function includes min/max range clipping
-        gain_u7 = _table_6_24_uint7_to_db(db)
+        gain_u7 = _table_6_24_db_to_uint7(db)
         self._page1._set_spk_volume(route_enabled=True, gain=gain_u7)
 
     @property

--- a/adafruit_tlv320.py
+++ b/adafruit_tlv320.py
@@ -2062,7 +2062,17 @@ class TLV320DAC3100:
 
     @property
     def headphone_output(self) -> bool:
-        """Headphone output helper with quickstart settings for users.
+        """Headphone output helper with quickstart default settings.
+
+        If you set this property to True, the setter will set defaults that
+        are intended for listening at a quiet-ish level with sensitive low
+        impedance earbuds:
+
+        * dac_volume = -30
+        * headphone_volume = -42.1
+        * headphone_left_gain = headphone_right_gain = 0
+
+        If you set this to False, the setter turns off the headphone amp.
 
         :getter: Return headphone output state: True if either left or right
             headphone amplifier is powered, False otherwise.
@@ -2078,17 +2088,11 @@ class TLV320DAC3100:
 
     @headphone_output.setter
     def headphone_output(self, enabled: bool) -> None:
-        # =========
-        # TODO: Consider if this should be changed to a regular function since
-        #       it modifies many properties. Note how the getter above only
-        #       checks the amplifier enable status but this setter does a bunch
-        #       of other stuff.
-        # =========
         if enabled:
             self.left_dac = True
             self.right_dac = True
-            self.left_dac_channel_volume = 0
-            self.right_dac_channel_volume = 0
+            self.left_dac_channel_volume = -30
+            self.right_dac_channel_volume = -30
             self.left_dac_mute = False
             self.right_dac_mute = False
             self.left_dac_path = DAC_PATH_NORMAL
@@ -2098,10 +2102,18 @@ class TLV320DAC3100:
             self._page1._configure_headphone_driver(
                 left_powered=True, right_powered=True, common=HP_COMMON_1_65V
             )
-            # ========
-            # TODO: Should probably set self.headphone_volume (-10? -20?)
-            # ========
-            self._page1._configure_analog_inputs(left_dac=DAC_ROUTE_HP, right_dac=DAC_ROUTE_HP)
+            self.headphone_volume = -42.1
+            # NOTE: If you use DAC_ROUTE_HP here instead of DAC_ROUTE_MIXER,
+            # the DAC output will bypass the headphone analog volume
+            # attenuation stage and go straight into the headphone amp. That
+            # might possibly be useful to save power, but it reduces your gain
+            # adjustment options. For low impedance headphones, it's helpful to
+            # have a lot of attenuation between the DAC and the headphone amp.
+            # Otherwise, you may have to operate the DAC volume setting down
+            # near the bottom of its usable range.
+            self._page1._configure_analog_inputs(
+                left_dac=DAC_ROUTE_MIXER, right_dac=DAC_ROUTE_MIXER
+            )
             self.headphone_left_mute = False
             self.headphone_right_mute = False
         else:
@@ -2109,7 +2121,15 @@ class TLV320DAC3100:
 
     @property
     def speaker_output(self) -> bool:
-        """Speaker output helper with quickstart settings for users.
+        """Speaker output helper with quickstart default settings.
+
+        If you set this property to True, the setter will set:
+
+        * dac_volume = -30
+        * speaker_volume = -42.1
+        * speaker_gain = 6
+
+        If you set this to False, the setter turns off the speaker amp.
 
         :getter: Return speaker output state: True if speaker amplifier is
             powered, False otherwise.
@@ -2121,17 +2141,11 @@ class TLV320DAC3100:
 
     @speaker_output.setter
     def speaker_output(self, enabled: bool) -> None:
-        # =========
-        # TODO: Consider if this should be changed to a regular function since
-        #       it modifies many properties. Note how the getter above only
-        #       checks the amplifier enable status but this setter does a bunch
-        #       of other stuff.
-        # =========
         if enabled:
             self.left_dac = True
             self.right_dac = True
-            self.left_dac_channel_volume = 0
-            self.right_dac_channel_volume = 0
+            self.left_dac_channel_volume = -30
+            self.right_dac_channel_volume = -30
             self.left_dac_mute = False
             self.right_dac_mute = False
             self.left_dac_path = DAC_PATH_NORMAL
@@ -2141,7 +2155,7 @@ class TLV320DAC3100:
             self._page1._configure_analog_inputs(
                 left_dac=DAC_ROUTE_MIXER, right_dac=DAC_ROUTE_MIXER
             )
-            self.speaker_volume = -20
+            self.speaker_volume = -42.1
             self.speaker_mute = False
         else:
             self._page1._set_speaker_enabled(False)

--- a/adafruit_tlv320.py
+++ b/adafruit_tlv320.py
@@ -609,7 +609,7 @@ class _Page0Registers(_PagedRegisterBase):
             "wclk_out": wclk_out,
         }
 
-    def _get_dac_data_path(self):
+    def _get_dac_data_path(self) -> dict:
         """The current DAC data path configuration.
 
         :return: Dictionary with DAC data path settings
@@ -629,7 +629,7 @@ class _Page0Registers(_PagedRegisterBase):
             "volume_step": volume_step,
         }
 
-    def _get_dac_volume_control(self):
+    def _get_dac_volume_control(self) -> dict:
         """The current DAC volume control configuration.
 
         :return: Dictionary with volume control settings
@@ -1083,9 +1083,9 @@ class TLV320DAC3100:
         self._device: I2CDevice = I2CDevice(i2c, address)
 
         # Initialize register page classes
-        self._page0: "Page0Registers" = _Page0Registers(self._device)
-        self._page1: "Page1Registers" = _Page1Registers(self._device)
-        self._page3: "Page3Registers" = _Page3Registers(self._device)
+        self._page0: "_Page0Registers" = _Page0Registers(self._device)
+        self._page1: "_Page1Registers" = _Page1Registers(self._device)
+        self._page3: "_Page3Registers" = _Page3Registers(self._device)
         self._sample_rate: int = 44100
         self._bit_depth: int = 16
         self._mclk_freq: int = 0  # Default blck
@@ -1198,7 +1198,7 @@ class TLV320DAC3100:
 
     @left_dac.setter
     def left_dac(self, enabled: bool) -> None:
-        current: DACDataPath = self._page0._get_dac_data_path()
+        current: dict = self._page0._get_dac_data_path()
         self._page0._set_dac_data_path(
             enabled,
             current["right_dac_on"],
@@ -1220,7 +1220,7 @@ class TLV320DAC3100:
 
     @right_dac.setter
     def right_dac(self, enabled: bool) -> None:
-        current: DACDataPath = self._page0._get_dac_data_path()
+        current: dict = self._page0._get_dac_data_path()
         self._page0._set_dac_data_path(
             current["left_dac_on"],
             enabled,
@@ -1250,7 +1250,7 @@ class TLV320DAC3100:
                 f"Invalid DAC path value: {path}. Must be one of the DAC_PATH_* constants."
             )
 
-        current: DACDataPath = self._page0._get_dac_data_path()
+        current: dict = self._page0._get_dac_data_path()
         self._page0._set_dac_data_path(
             current["left_dac_on"],
             current["right_dac_on"],
@@ -1280,7 +1280,7 @@ class TLV320DAC3100:
                 f"Invalid DAC path value: {path}. Must be one of the DAC_PATH_* constants."
             )
 
-        current: DACDataPath = self._page0._get_dac_data_path()
+        current: dict = self._page0._get_dac_data_path()
         self._page0._set_dac_data_path(
             current["left_dac_on"],
             current["right_dac_on"],
@@ -1310,7 +1310,7 @@ class TLV320DAC3100:
                 f"Invalid volume step value: {step}. Must be one of the VOLUME_STEP_* constants."
             )
 
-        current: DACDataPath = self._page0._get_dac_data_path()
+        current: dict = self._page0._get_dac_data_path()
         self._page0._set_dac_data_path(
             current["left_dac_on"],
             current["right_dac_on"],
@@ -1368,7 +1368,7 @@ class TLV320DAC3100:
 
     @left_dac_mute.setter
     def left_dac_mute(self, mute: bool) -> None:
-        current: DACVolumeControl = self._page0._get_dac_volume_control()
+        current: dict = self._page0._get_dac_volume_control()
         self._page0._set_dac_volume_control(mute, current["right_mute"], current["control"])
 
     @property
@@ -1384,7 +1384,7 @@ class TLV320DAC3100:
 
     @right_dac_mute.setter
     def right_dac_mute(self, mute: bool) -> None:
-        current: DACVolumeControl = self._page0._get_dac_volume_control()
+        current: dict = self._page0._get_dac_volume_control()
         self._page0._set_dac_volume_control(current["left_mute"], mute, current["control"])
 
     @property
@@ -1406,7 +1406,7 @@ class TLV320DAC3100:
             raise ValueError(
                 f"Invalid volume control mode: {mode}. Must be one of the VOL_* constants."
             )
-        current: DACVolumeControl = self._page0._get_dac_volume_control()
+        current: dict = self._page0._get_dac_volume_control()
         self._page0._set_dac_volume_control(current["left_mute"], current["right_mute"], mode)
 
     @property
@@ -2201,7 +2201,7 @@ class TLV320DAC3100:
     @speaker_volume.setter
     def speaker_volume(self, db: float) -> None:
         # The table 6-24 lookup function includes min/max range clipping
-        gain_u7 = _table_6_24_uint7_to_dB(db)
+        gain_u7 = _table_6_24_uint7_to_db(db)
         self._page1._set_spk_volume(route_enabled=True, gain=gain_u7)
 
     @property

--- a/adafruit_tlv320.py
+++ b/adafruit_tlv320.py
@@ -36,7 +36,7 @@ Implementation Notes
   start with lower levels for ``speaker_volume`` and ``speaker_gain``, then work
   your way up to find a comfortable listening level. Similarly, for the
   headphone output, start low with ``headphone_volume``,
-  ``headphone_left_gain``\, and ``headphone_right_gain``\, then increase as
+  ``headphone_left_gain``, and ``headphone_right_gain``, then increase as
   needed.
 
 **Software and Dependencies:**
@@ -1481,10 +1481,10 @@ class TLV320DAC3100:
 
         Changing the DAC volume will change the signal level feeding into the
         analog signal chains of the speaker and both headphone channels. You
-        should also be aware of ``speaker_volume``\, ``speaker_gain``\,
-        ``speaker_mute``\, ``headphone_volume``\, ``headphone_left_gain``\,
-        ``headphone_right_gain``\, ``headphone_left_mute``\, and
-        ``headphone_right_mute``\.
+        should also be aware of ``speaker_volume``, ``speaker_gain``,
+        ``speaker_mute``, ``headphone_volume``, ``headphone_left_gain``,
+        ``headphone_right_gain``, ``headphone_left_mute``, and
+        ``headphone_right_mute``.
 
         :getter: Return volume
         :setter: Set volume
@@ -1567,7 +1567,7 @@ class TLV320DAC3100:
         In the datasheet, this is Page 1 / Register 40 (0x28): HPL Driver.
 
         Note that the headphone left channel volume is also affected by
-        ``dac_volume``\, ``headphone_volume``\, and ``headphone_left_mute``\.
+        ``dac_volume``, ``headphone_volume``, and ``headphone_left_mute``.
 
         :getter: Return gain
         :setter: Set gain
@@ -1609,7 +1609,7 @@ class TLV320DAC3100:
         In the datasheet, this is Page 1 / Register 41 (0x29): HPR Driver.
 
         Note that the headphone right channel volume is also affected by
-        ``dac_volume``\, ``headphone_volume``\, and ``headphone_right_mute``\.
+        ``dac_volume``, ``headphone_volume``, and ``headphone_right_mute``.
 
         :getter: Return gain
         :setter: Set gain
@@ -1650,7 +1650,7 @@ class TLV320DAC3100:
         In the datasheet, this is Page 1 / Register 42 (0x2A): Class-D Speaker
         (SPK) Driver.
 
-        Note that ``dac_volume``\, ``speaker_volume``\, and ``speaker_mute``
+        Note that ``dac_volume``, ``speaker_volume``, and ``speaker_mute``
         also affect the speaker output level.
 
         :getter: Return gain
@@ -2173,9 +2173,9 @@ class TLV320DAC3100:
         * Page 1 / Register 36 (0x24): Left Analog Volume to HPL
         * Page 1 / Register 37 (0x25) Right Analog Volume to HPR
 
-        Note that headphone output is also affected by ``dac_volume``\,
-        ``headphone_left_gain``\, ``headphone_right_gain``\,
-        ``headphone_left_mute``\, and ``headphone_right_mute``\.
+        Note that headphone output is also affected by ``dac_volume``,
+        ``headphone_left_gain``, ``headphone_right_gain``,
+        ``headphone_left_mute``, and ``headphone_right_mute``.
 
         :getter: Return volume
         :setter: Set volume
@@ -2205,7 +2205,7 @@ class TLV320DAC3100:
         In the datasheet, this is Page 1 / Register 38 (0x26): Left Analog
         Volume to SPK.
 
-        Note that ``dac_volume``\, ``speaker_gain``\, and ``speaker_mute`` also
+        Note that ``dac_volume``, ``speaker_gain``, and ``speaker_mute`` also
         affect the speaker output level.
 
         :getter: Return volume

--- a/adafruit_tlv320.py
+++ b/adafruit_tlv320.py
@@ -1117,7 +1117,8 @@ class TLV320DAC3100:
     def overtemperature(self) -> bool:
         """Check if the chip is overheating.
 
-        :return: True if overtemperature condition exists, False otherwise
+        :getter: Return True if overtemperature condition exists, False
+            otherwise
         """
         return self._page0._is_overtemperature()
 
@@ -1188,16 +1189,15 @@ class TLV320DAC3100:
     def left_dac(self) -> bool:
         """The left DAC enabled status.
 
-        :return: True if left DAC is enabled, False otherwise
+        True if left DAC is enabled, False otherwise
+
+        :getter: Return status
+        :setter: Set status
         """
         return self._page0._get_dac_data_path()["left_dac_on"]
 
     @left_dac.setter
     def left_dac(self, enabled: bool) -> None:
-        """The left DAC enabled status.
-
-        :param enabled: True to enable left DAC, False to disable
-        """
         current: DACDataPath = self._page0._get_dac_data_path()
         self._page0._set_dac_data_path(
             enabled,
@@ -1211,16 +1211,15 @@ class TLV320DAC3100:
     def right_dac(self) -> bool:
         """The right DAC enabled status.
 
-        :return: True if right DAC is enabled, False otherwise
+        True if right DAC is enabled, False otherwise.
+
+        :getter: Return status
+        :setter: Set status
         """
         return self._page0._get_dac_data_path()["right_dac_on"]
 
     @right_dac.setter
     def right_dac(self, enabled: bool) -> None:
-        """The right DAC enabled status.
-
-        :param enabled: True to enable right DAC, False to disable
-        """
         current: DACDataPath = self._page0._get_dac_data_path()
         self._page0._set_dac_data_path(
             current["left_dac_on"],
@@ -1234,17 +1233,16 @@ class TLV320DAC3100:
     def left_dac_path(self) -> int:
         """The left DAC path setting.
 
-        :return: One of the DAC_PATH_* constants
+        One of the DAC_PATH_* constants
+
+        :getter: Return left DAC path
+        :setter: Set left DAC path
+        :raises ValueError: If set to something that's not a DAC_PATH_* constant
         """
         return self._page0._get_dac_data_path()["left_path"]
 
     @left_dac_path.setter
     def left_dac_path(self, path: int) -> None:
-        """The left DAC path.
-
-        :param path: One of the DAC_PATH_* constants
-        :raises ValueError: If path is not a valid DAC_PATH_* constant
-        """
         valid_paths: List[int] = [DAC_PATH_OFF, DAC_PATH_NORMAL, DAC_PATH_SWAPPED, DAC_PATH_MIXED]
 
         if path not in valid_paths:
@@ -1265,17 +1263,16 @@ class TLV320DAC3100:
     def right_dac_path(self) -> int:
         """The right DAC path setting.
 
-        :return: One of the DAC_PATH_* constants
+        One of the DAC_PATH_* constants
+
+        :getter: Return right DAC path
+        :setter: Set right DAC path
+        :raises ValueError: If set to something that's not a DAC_PATH_* constant
         """
         return self._page0._get_dac_data_path()["right_path"]
 
     @right_dac_path.setter
     def right_dac_path(self, path: int) -> None:
-        """The right DAC path.
-
-        :param path: One of the DAC_PATH_* constants
-        :raises ValueError: If path is not a valid DAC_PATH_* constant
-        """
         valid_paths: List[int] = [DAC_PATH_OFF, DAC_PATH_NORMAL, DAC_PATH_SWAPPED, DAC_PATH_MIXED]
 
         if path not in valid_paths:
@@ -1296,17 +1293,16 @@ class TLV320DAC3100:
     def dac_volume_step(self) -> int:
         """The DAC volume step setting.
 
-        :return: One of the VOLUME_STEP_* constants
+        One of the VOLUME_STEP_* constants.
+
+        :getter: Return current volume step
+        :setter: Set volume step
+        :raises ValueError: If step is not a valid VOLUME_STEP_* constant
         """
         return self._page0._get_dac_data_path()["volume_step"]
 
     @dac_volume_step.setter
     def dac_volume_step(self, step: int) -> None:
-        """The DAC volume step setting.
-
-        :param step: One of the VOLUME_STEP_* constants
-        :raises ValueError: If step is not a valid VOLUME_STEP_* constant
-        """
         valid_steps: List[int] = [VOLUME_STEP_1SAMPLE, VOLUME_STEP_2SAMPLE, VOLUME_STEP_DISABLED]
 
         if step not in valid_steps:
@@ -1363,16 +1359,15 @@ class TLV320DAC3100:
     def left_dac_mute(self) -> bool:
         """The left DAC mute status.
 
-        :return: True if left DAC is muted, False otherwise
+        True if left DAC is muted, False otherwise.
+
+        :getter: Return status
+        :setter: Set status
         """
         return self._page0._get_dac_volume_control()["left_mute"]
 
     @left_dac_mute.setter
     def left_dac_mute(self, mute: bool) -> None:
-        """The left DAC mute status.
-
-        :param mute: True to mute left DAC, False to unmute
-        """
         current: DACVolumeControl = self._page0._get_dac_volume_control()
         self._page0._set_dac_volume_control(mute, current["right_mute"], current["control"])
 
@@ -1380,16 +1375,15 @@ class TLV320DAC3100:
     def right_dac_mute(self) -> bool:
         """The right DAC mute status.
 
-        :return: True if right DAC is muted, False otherwise
+        True if right DAC is muted, False otherwise.
+
+        :getter: Return status
+        :setter: Set status
         """
         return self._page0._get_dac_volume_control()["right_mute"]
 
     @right_dac_mute.setter
     def right_dac_mute(self, mute: bool) -> None:
-        """The right DAC mute status.
-
-        :param mute: True to mute right DAC, False to unmute
-        """
         current: DACVolumeControl = self._page0._get_dac_volume_control()
         self._page0._set_dac_volume_control(current["left_mute"], mute, current["control"])
 
@@ -1397,17 +1391,16 @@ class TLV320DAC3100:
     def dac_volume_control_mode(self) -> int:
         """The DAC volume control mode.
 
-        :return: One of the VOL_* constants
+        One of the VOL_* constants.
+
+        :getter: Return mode
+        :setter: Set mode
+        :raises ValueError: If mode is not a valid VOL_* constant
         """
         return self._page0._get_dac_volume_control()["control"]
 
     @dac_volume_control_mode.setter
     def dac_volume_control_mode(self, mode: int) -> None:
-        """The volume control mode.
-
-        :param mode: One of the VOL_* constants for volume control mode
-        :raises ValueError: If mode is not a valid VOL_* constant
-        """
         valid_modes: List[int] = [VOL_INDEPENDENT, VOL_LEFT_TO_RIGHT, VOL_RIGHT_TO_LEFT]
         if mode not in valid_modes:
             raise ValueError(
@@ -1420,32 +1413,26 @@ class TLV320DAC3100:
     def left_dac_channel_volume(self) -> float:
         """Left DAC channel volume in dB.
 
-        :return: Volume in dB
+        :getter: Return volume
+        :setter: Set volume
         """
         return self._page0._get_channel_volume(False)
 
     @left_dac_channel_volume.setter
     def left_dac_channel_volume(self, db: float) -> None:
-        """Left DAC channel volume in dB.
-
-        :param db: Volume in dB
-        """
         self._page0._set_channel_volume(False, db)
 
     @property
     def right_dac_channel_volume(self) -> float:
         """Right DAC channel volume in dB.
 
-        :return: Volume in dB
+        :getter: Return volume
+        :setter: Set volume
         """
         return self._page0._get_channel_volume(True)
 
     @right_dac_channel_volume.setter
     def right_dac_channel_volume(self, db: float) -> None:
-        """Right DAC channel volume in dB.
-
-        :param db: Volume in dB
-        """
         self._page0._set_channel_volume(True, db)
 
     @staticmethod
@@ -1498,6 +1485,9 @@ class TLV320DAC3100:
         ``speaker_mute``\, ``headphone_volume``\, ``headphone_left_gain``\,
         ``headphone_right_gain``\, ``headphone_left_mute``\, and
         ``headphone_right_mute``\.
+
+        :getter: Return volume
+        :setter: Set volume
         """
         left_vol = self._page0._read_register(_DAC_LVOL)
         right_vol = self._page0._read_register(_DAC_RVOL)
@@ -1579,6 +1569,8 @@ class TLV320DAC3100:
         Note that the headphone left channel volume is also affected by
         ``dac_volume``\, ``headphone_volume``\, and ``headphone_left_mute``\.
 
+        :getter: Return gain
+        :setter: Set gain
         :raises ValueError: If set to a value outside the range of 0 to 9
         """
         reg_value = self._page1._read_register(_HPL_DRIVER)
@@ -1595,6 +1587,9 @@ class TLV320DAC3100:
         """Left headphone mute status.
 
         True means left headphone is muted, False means not muted.
+
+        :getter: Return status
+        :setter: Set status
         """
         reg_value = self._page1._read_register(_HPL_DRIVER)
         return not bool(reg_value & (1 << 2))
@@ -1616,6 +1611,8 @@ class TLV320DAC3100:
         Note that the headphone right channel volume is also affected by
         ``dac_volume``\, ``headphone_volume``\, and ``headphone_right_mute``\.
 
+        :getter: Return gain
+        :setter: Set gain
         :raises ValueError: If set to a value outside the range of 0 to 9
         """
         reg_value = self._page1._read_register(_HPR_DRIVER)
@@ -1632,6 +1629,9 @@ class TLV320DAC3100:
         """Right headphone mute status.
 
         True means right headphone is muted, False means not muted.
+
+        :getter: Return status
+        :setter: Set status
         """
         reg_value = self._page1._read_register(_HPR_DRIVER)
         return not bool(reg_value & (1 << 2))
@@ -1653,6 +1653,8 @@ class TLV320DAC3100:
         Note that ``dac_volume``\, ``speaker_volume``\, and ``speaker_mute``
         also affect the speaker output level.
 
+        :getter: Return gain
+        :setter: Set gain
         :raises ValueError: If set to anything other than 6, 12, 18, or 24
         """
         # This gives us a 2-bit unsigned integer where 0 means 6 dB, 1 is 12 dB,
@@ -1662,9 +1664,6 @@ class TLV320DAC3100:
 
     @speaker_gain.setter
     def speaker_gain(self, gain_db: int) -> None:
-        """
-        :raises ValueError: If set to anything other than 6, 12, 18, or 24
-        """
         unmute = not self.speaker_mute
         # This relies on _configure_spk_pga() to raise ValueError if the gain
         # value is out of range
@@ -1675,6 +1674,9 @@ class TLV320DAC3100:
         """The speaker mute status.
 
         True means speaker is muted, False means unmuted.
+
+        :getter: Return status
+        :setter: Set status
         """
         reg_value = self._page1._read_register(_SPK_DRIVER)
         return not bool(reg_value & (1 << 2))
@@ -1689,7 +1691,7 @@ class TLV320DAC3100:
     def dac_flags(self) -> Dict[str, Any]:
         """The DAC and output driver status flags.
 
-        :return: Dictionary with status flags
+        :getter: Return dictionary with status flags
         """
         return self._page0._get_dac_flags()
 
@@ -1697,18 +1699,17 @@ class TLV320DAC3100:
     def gpio1_mode(self) -> int:
         """The current GPIO1 pin mode.
 
-        :return: One of the GPIO1_* mode constants
+        One of the GPIO1_* mode constants.
+
+        :getter: Return mode
+        :setter: Set mode
+        :raises ValueError: If mode is not a valid GPIO1_* constant
         """
         value = self._page0._read_register(_GPIO1_CTRL)
         return (value >> 2) & 0x0F
 
     @gpio1_mode.setter
     def gpio1_mode(self, mode: int) -> None:
-        """The GPIO1 pin mode.
-
-        :param mode: One of the GPIO1_* mode constants
-        :raises ValueError: If mode is not a valid GPIO1_* constant
-        """
         valid_modes: List[int] = [
             GPIO1_DISABLED,
             GPIO1_INPUT_MODE,
@@ -1730,7 +1731,7 @@ class TLV320DAC3100:
     def din_input(self) -> int:
         """The current DIN input value.
 
-        :return: The DIN input value
+        :getter: Return the DIN input value
         """
         return self._page0._get_din_input()
 
@@ -1738,7 +1739,7 @@ class TLV320DAC3100:
     def codec_interface(self) -> Dict[str, Any]:
         """The current codec interface settings.
 
-        :return: Dictionary with codec interface settings
+        :getter: Return dictionary with codec interface settings
         """
         return self._page0._get_codec_interface()
 
@@ -1746,7 +1747,7 @@ class TLV320DAC3100:
     def headphone_shorted(self) -> bool:
         """Check if headphone short circuit is detected.
 
-        :return: True if headphone is shorted, False otherwise
+        :getter: Return True if headphone is shorted, False otherwise
         """
         return self._page1._is_headphone_shorted()
 
@@ -1754,7 +1755,7 @@ class TLV320DAC3100:
     def speaker_shorted(self) -> bool:
         """Check if speaker short circuit is detected.
 
-        :return: True if speaker is shorted, False otherwise
+        :getter: Return True if speaker is shorted, False otherwise
         """
         return self._page1._is_speaker_shorted()
 
@@ -1762,7 +1763,7 @@ class TLV320DAC3100:
     def hpl_gain_applied(self) -> bool:
         """Check if all programmed gains have been applied to HPL.
 
-        :return: True if gains are applied, False otherwise
+        :getter: Return True if gains are applied, False otherwise
         """
         return self._page1._is_hpl_gain_applied()
 
@@ -1770,7 +1771,7 @@ class TLV320DAC3100:
     def hpr_gain_applied(self) -> bool:
         """Check if all programmed gains have been applied to HPR.
 
-        :return: True if gains are applied, False otherwise
+        :getter: Return True if gains are applied, False otherwise
         """
         return self._page1._is_hpr_gain_applied()
 
@@ -1778,7 +1779,7 @@ class TLV320DAC3100:
     def speaker_gain_applied(self) -> bool:
         """Check if all programmed gains have been applied to Speaker.
 
-        :return: True if gains are applied, False otherwise
+        :getter: Return True if gains are applied, False otherwise
         """
         return self._page1._is_spk_gain_applied()
 
@@ -1786,40 +1787,41 @@ class TLV320DAC3100:
     def headset_status(self) -> int:
         """Current headset detection status.
 
-        :return: Integer value representing headset status (0=none, 1=without mic, 3=with mic)
+        :getter: Return Integer value representing headset status (0=none,
+            1=without mic, 3=with mic)
         """
         return self._page0._get_headset_status()
 
     @property
     def reset_speaker_on_scd(self) -> bool:
-        """The speaker reset behavior on short circuit detection.
+        """The speaker reset mode for short circuit detection.
 
-        :return: True if speaker resets on short circuit, False otherwise
+        True if speaker resets on short circuit, False otherwise.
+
+        :getter: Return mode
+        :setter: Set mode
         """
         value = self._page1._read_register(_HP_SPK_ERR_CTL)
         return not bool((value >> 1) & 0x01)
 
     @reset_speaker_on_scd.setter
     def reset_speaker_on_scd(self, reset: bool) -> None:
-        """
-        :param reset: True to reset speaker on short circuit, False to remain unchanged
-        """
         self._page1._reset_speaker_on_scd(reset)
 
     @property
     def reset_headphone_on_scd(self) -> bool:
-        """The headphone reset behavior on short circuit detection.
+        """The headphone reset mode for short circuit detection.
 
-        :return: True if headphone resets on short circuit, False otherwise
+        True if headphone resets on short circuit, False otherwise.
+
+        :getter: Return mode
+        :setter: Set mode
         """
         value = self._page1._read_register(_HP_SPK_ERR_CTL)
         return not bool(value & 0x01)
 
     @reset_headphone_on_scd.setter
     def reset_headphone_on_scd(self, reset: bool) -> None:
-        """
-        :param reset: True to reset headphone on short circuit, False to remain unchanged
-        """
         self._page1._reset_headphone_on_scd(reset)
 
     def configure_headphone_pop(
@@ -1838,24 +1840,25 @@ class TLV320DAC3100:
     def speaker_wait_time(self) -> int:
         """The current speaker power-up wait time.
 
-        :return: The wait time setting (0-7)
+        Speaker power-up wait duration (0-7).
+
+        :getter: Return wait time
+        :setter: Set wait time
         """
         value = self._page1._read_register(_PGA_RAMP)
         return (value >> 4) & 0x07
 
     @speaker_wait_time.setter
     def speaker_wait_time(self, wait_time: int) -> None:
-        """Speaker power-up wait time.
-
-        :param wait_time: Speaker power-up wait duration (0-7)
-        """
         self._page1._set_speaker_wait_time(wait_time)
 
     @property
     def headphone_lineout(self) -> bool:
         """The current headphone line-out configuration.
 
-        :return: True if both channels are configured as line-out, False otherwise
+        :getter: Return True if both channels are configured as line-out, False
+            otherwise
+        :setter: True to configure both channels as line-out, False otherwise
         """
         value = self._page1._read_register(_HP_DRIVER_CTRL)
         left = bool(value & (1 << 2))
@@ -1864,9 +1867,6 @@ class TLV320DAC3100:
 
     @headphone_lineout.setter
     def headphone_lineout(self, enabled: bool) -> None:
-        """
-        :param enabled: True to configure both channels as line-out, False otherwise
-        """
         self._page1._headphone_lineout(enabled, enabled)
 
     def config_mic_bias(
@@ -1903,16 +1903,20 @@ class TLV320DAC3100:
     def vol_adc_pin_control(self) -> bool:
         """The volume ADC pin control status.
 
-        :return: True if volume ADC pin control is enabled, False otherwise
+        True if volume ADC pin control is enabled, False otherwise.
+
+        This is for using an analog input pin, probably connected to a
+        potentiometer, to control the volume. You can ignore this if you want
+        to control volume from software over I2C.
+
+        :getter: Return status
+        :setter: Set status
         """
         reg_value = self._page0._read_register(_VOL_ADC_CTRL)
         return bool(reg_value & (1 << 7))
 
     @vol_adc_pin_control.setter
     def vol_adc_pin_control(self, enabled: bool) -> None:
-        """
-        :param enabled: True to enable volume ADC pin control, False to disable
-        """
         current_config = self._get_vol_adc_config()
         self._page0._config_vol_adc(
             enabled,
@@ -1925,16 +1929,16 @@ class TLV320DAC3100:
     def vol_adc_use_mclk(self) -> bool:
         """The volume ADC use MCLK status.
 
-        :return: True if volume ADC uses MCLK, False otherwise
+        True means volume ADC uses MCLK, False means internal oscillator.
+
+        :getter: Return status
+        :setter: Set status
         """
         reg_value = self._page0._read_register(_VOL_ADC_CTRL)
         return bool(reg_value & (1 << 6))
 
     @vol_adc_use_mclk.setter
     def vol_adc_use_mclk(self, use_mclk: bool) -> None:
-        """
-        :param use_mclk: True to use MCLK, False to use internal oscillator
-        """
         current_config = self._get_vol_adc_config()
         self._page0._config_vol_adc(
             current_config["pin_control"],
@@ -1947,16 +1951,16 @@ class TLV320DAC3100:
     def vol_adc_hysteresis(self) -> int:
         """The volume ADC hysteresis setting.
 
-        :return: Hysteresis value (0-3)
+        Hysteresis value (0-3).
+
+        :getter: Return value
+        :setter: Set value
         """
         reg_value = self._page0._read_register(_VOL_ADC_CTRL)
         return (reg_value >> 4) & 0x03
 
     @vol_adc_hysteresis.setter
     def vol_adc_hysteresis(self, hysteresis: int) -> None:
-        """
-        :param hysteresis: Hysteresis value (0-3)
-        """
         current_config = self._get_vol_adc_config()
         self._page0._config_vol_adc(
             current_config["pin_control"],
@@ -1969,17 +1973,16 @@ class TLV320DAC3100:
     def vol_adc_rate(self) -> int:
         """The volume ADC sampling rate.
 
-        :return: Rate value (0-7)
+        Rate value (0-7).
+
+        :getter: Return value
+        :setter: Set value
         """
         reg_value = self._page0._read_register(_VOL_ADC_CTRL)
         return reg_value & 0x07
 
     @vol_adc_rate.setter
     def vol_adc_rate(self, rate: int) -> None:
-        """
-
-        :param rate: Rate value (0-7)
-        """
         current_config = self._get_vol_adc_config()
         self._page0._config_vol_adc(
             current_config["pin_control"],
@@ -2005,7 +2008,7 @@ class TLV320DAC3100:
     def vol_adc_db(self) -> float:
         """The current volume from the Volume ADC in dB.
 
-        :return: Volume in dB
+        :getter: Return Volume in dB
         """
         return self._page0._read_vol_adc_db()
 
@@ -2060,9 +2063,13 @@ class TLV320DAC3100:
     @property
     def headphone_output(self) -> bool:
         """Headphone output helper with quickstart settings for users.
-        Headphone output state (True if either left or right channel is powered).
 
-        :return: True if headphone output is enabled, False otherwise
+        :getter: Return headphone output state: True if either left or right
+            headphone amplifier is powered, False otherwise.
+        :setter: **This sets several properties to prepare for headphone use**.
+            Changed properties include DAC channel enable/volume/mute, DAC
+            path, headphone gain, headphone common mode voltage, and headphone
+            mute.
         """
         hp_drivers = self._page1._read_register(_HP_DRIVERS)
         left_powered = bool(hp_drivers & (1 << 7))
@@ -2071,9 +2078,12 @@ class TLV320DAC3100:
 
     @headphone_output.setter
     def headphone_output(self, enabled: bool) -> None:
-        """
-        :param enabled: True to enable headphone output, False to disable
-        """
+        # =========
+        # TODO: Consider if this should be changed to a regular function since
+        #       it modifies many properties. Note how the getter above only
+        #       checks the amplifier enable status but this setter does a bunch
+        #       of other stuff.
+        # =========
         if enabled:
             self.left_dac = True
             self.right_dac = True
@@ -2088,6 +2098,9 @@ class TLV320DAC3100:
             self._page1._configure_headphone_driver(
                 left_powered=True, right_powered=True, common=HP_COMMON_1_65V
             )
+            # ========
+            # TODO: Should probably set self.headphone_volume (-10? -20?)
+            # ========
             self._page1._configure_analog_inputs(left_dac=DAC_ROUTE_HP, right_dac=DAC_ROUTE_HP)
             self.headphone_left_mute = False
             self.headphone_right_mute = False
@@ -2097,17 +2110,23 @@ class TLV320DAC3100:
     @property
     def speaker_output(self) -> bool:
         """Speaker output helper with quickstart settings for users.
-        Speaker output state.
 
-        :return: True if speaker output is enabled, False otherwise
+        :getter: Return speaker output state: True if speaker amplifier is
+            powered, False otherwise.
+        :setter: **This sets several properties to prepare for speaker use**.
+            Changed properties include DAC channel enable/volume/mute, DAC
+            path, speaker volume, speaker amplifier gain, and speaker mute.
         """
         return self._page1._get_speaker_enabled()
 
     @speaker_output.setter
     def speaker_output(self, enabled: bool) -> None:
-        """
-        :param enabled: True to enable speaker, False to disable
-        """
+        # =========
+        # TODO: Consider if this should be changed to a regular function since
+        #       it modifies many properties. Note how the getter above only
+        #       checks the amplifier enable status but this setter does a bunch
+        #       of other stuff.
+        # =========
         if enabled:
             self.left_dac = True
             self.right_dac = True
@@ -2136,12 +2155,14 @@ class TLV320DAC3100:
         This acts on two registers at once. In the datasheet they are:
 
         * Page 1 / Register 36 (0x24): Left Analog Volume to HPL
-
         * Page 1 / Register 37 (0x25) Right Analog Volume to HPR
 
         Note that headphone output is also affected by ``dac_volume``\,
         ``headphone_left_gain``\, ``headphone_right_gain``\,
         ``headphone_left_mute``\, and ``headphone_right_mute``\.
+
+        :getter: Return volume
+        :setter: Set volume
         """
         left_gain_u7 = self._page1._read_register(_HPL_VOL) & 0x7F
         right_gain_u7 = self._page1._read_register(_HPR_VOL) & 0x7F
@@ -2170,6 +2191,9 @@ class TLV320DAC3100:
 
         Note that ``dac_volume``\, ``speaker_gain``\, and ``speaker_mute`` also
         affect the speaker output level.
+
+        :getter: Return volume
+        :setter: Set volume
         """
         gain_u7 = self._page1._read_register(_SPK_VOL) & 0x7F
         return _table_6_24_uint7_to_db(gain_u7)
@@ -2184,7 +2208,7 @@ class TLV320DAC3100:
     def sample_rate(self) -> int:
         """Configured sample rate in Hz.
 
-        :return: The sample rate in Hz
+        :getter: Return The sample rate in Hz
         """
         return self._sample_rate
 
@@ -2192,7 +2216,7 @@ class TLV320DAC3100:
     def bit_depth(self) -> int:
         """Configured bit depth.
 
-        :return: The bit depth
+        :getter: Return The bit depth
         """
         return self._bit_depth
 
@@ -2200,6 +2224,6 @@ class TLV320DAC3100:
     def mclk_freq(self) -> int:
         """Configured MCLK frequency in Hz.
 
-        :return: The MCLK frequency in Hz
+        :getter: Return The MCLK frequency in Hz
         """
         return self._mclk_freq

--- a/adafruit_tlv320.py
+++ b/adafruit_tlv320.py
@@ -349,7 +349,7 @@ TABLE_6_24 = (
 )
 
 
-def _table_6_24_db_to_uint7(self, db: float) -> int:
+def _table_6_24_db_to_uint7(db: float) -> int:
     """Convert gain dB to 7-bit unsigned int following datasheet Table 6-24.
 
     :param db: Analog gain in dB; range is 0 dB (loud) to -78.3 dB (soft)
@@ -371,7 +371,7 @@ def _table_6_24_db_to_uint7(self, db: float) -> int:
     return result
 
 
-def _table_6_24_uint7_to_db(self, u7: int) -> float:
+def _table_6_24_uint7_to_db(u7: int) -> float:
     """Convert 7-bit unsigned int to gain dB following datasheet Table 6-24.
 
     :param u7: 7-bit unsigned int value, range is 0 (loud) to 127 (soft)
@@ -951,7 +951,7 @@ class _Page1Registers(_PagedRegisterBase):
         """
         if gain_db not in set((6, 12, 18, 24)):
             raise ValueError(f"Invalid speaker gain: {gain_db}. Must be 6, 12, 18, or 24.")
-        uint2_val = (gain_db / 6) - 1
+        uint2_val = int((gain_db / 6) - 1)
         value = (uint2_val & 0x03) << 3
         if unmute:
             value |= 1 << 2

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,4 @@
+/* Monkey patch the rtd theme to prevent horizontal stacking of short items
+ * see https://github.com/readthedocs/sphinx_rtd_theme/issues/1301
+*/
+.py.property{display: block !important;}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,4 +1,8 @@
+/* SPDX-FileCopyrightText: 2025 Sam Blenny
+ * SPDX-License-Identifier: MIT
+ */
+
 /* Monkey patch the rtd theme to prevent horizontal stacking of short items
  * see https://github.com/readthedocs/sphinx_rtd_theme/issues/1301
-*/
+ */
 .py.property{display: block !important;}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,9 @@ autodoc_mock_imports = ["digitalio", "busio", "adafruit_bus_device", "micropytho
 
 autodoc_preserve_defaults = True
 
+# Override the default config in which autodoc sorts things alphabetically
+autodoc_member_order = 'groupwise'
+
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "BusDevice": ("https://docs.circuitpython.org/projects/busdevice/en/latest/", None),
@@ -116,6 +119,9 @@ html_theme = "sphinx_rtd_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+# Include extra css to work around rtd theme glitches
+html_css_files = ['custom.css']
 
 # The name of an image file (relative to this directory) to use as a favicon of
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ autodoc_mock_imports = ["digitalio", "busio", "adafruit_bus_device", "micropytho
 autodoc_preserve_defaults = True
 
 # Override the default config in which autodoc sorts things alphabetically
-autodoc_member_order = 'groupwise'
+autodoc_member_order = "groupwise"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
@@ -121,7 +121,7 @@ html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
 
 # Include extra css to work around rtd theme glitches
-html_css_files = ['custom.css']
+html_css_files = ["custom.css"]
 
 # The name of an image file (relative to this directory) to use as a favicon of
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -15,3 +15,12 @@ Demos advanced features of the library.
 .. literalinclude:: ../examples/tlv320_fulltest.py
     :caption: examples/tlv320_fulltest.py
     :linenos:
+
+Volume test
+-----------
+
+Test tone generator with interactive serial console volume controls
+
+.. literalinclude:: ../examples/tlv320_volumetest.py
+    :caption: examples/tlv320_volumetest.py
+    :linenos:

--- a/examples/tlv320_volumetest.py
+++ b/examples/tlv320_volumetest.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright 2025 Sam Blenny
+#
+import gc
+import os
+import sys
+import time
+
+import displayio
+import supervisor
+import synthio
+from audiobusio import I2SOut
+from board import I2C, I2S_BCLK, I2S_DIN, I2S_MCLK, I2S_WS, PERIPH_RESET
+from digitalio import DigitalInOut, Direction, Pull
+from micropython import const
+
+from adafruit_tlv320 import TLV320DAC3100
+
+# DAC and Synthesis parameters
+SAMPLE_RATE = const(11025)
+CHAN_COUNT = const(2)
+BUFFER_SIZE = const(1024)
+
+# DAC volume limits
+DV_MIN = -63.5
+DV_MAX = 24.0
+
+# Headphone volume limits
+HV_MIN = -78.3
+HV_MAX = 0
+
+# Headphone gain limits
+HG_MIN = 0
+HG_MAX = 9
+
+# Speaker volume limits
+SV_MIN = -78.3
+SV_MAX = 0
+
+# Speaker amp gain limits
+SG_MIN = 6
+SG_MAX = 24
+SG_STEP = 6
+
+
+def init_dac_audio_synth(i2c):
+    """Configure TLV320 I2S DAC for audio output and make a Synthesizer.
+
+    :param i2c: a reference to board.I2C()
+    :return: tuple(dac: TLV320DAC3100, audio: I2SOut, synth: Synthesizer)
+    """
+    # 1. Reset DAC (reset is active low)
+    rst = DigitalInOut(PERIPH_RESET)
+    rst.direction = Direction.OUTPUT
+    rst.value = False
+    time.sleep(0.1)
+    rst.value = True
+    time.sleep(0.05)
+    # 2. Configure sample rate, bit depth, and output port
+    dac = TLV320DAC3100(i2c)
+    dac.configure_clocks(sample_rate=SAMPLE_RATE, bit_depth=16)
+    dac.speaker_output = True
+    dac.headphone_output = True
+    # 4. Initialize I2S for Fruit Jam rev D
+    audio = I2SOut(bit_clock=I2S_BCLK, word_select=I2S_WS, data=I2S_DIN)
+    # 5. Configure synthio patch to generate audio
+    vca = synthio.Envelope(
+        attack_time=0, decay_time=0, sustain_level=1.0, release_time=0, attack_level=1.0
+    )
+    synth = synthio.Synthesizer(sample_rate=SAMPLE_RATE, channel_count=CHAN_COUNT, envelope=vca)
+    return (dac, audio, synth)
+
+
+def main():  # noqa: PLR0912, PLR0915, allow long function and long if statement
+    # Turn off the default DVI display to free up CPU
+    displayio.release_displays()
+    gc.collect()
+
+    # Set up the audio stuff for a basic synthesizer
+    i2c = I2C()
+    (dac, audio, synth) = init_dac_audio_synth(i2c)
+    audio.play(synth)
+
+    dv = dac.dac_volume  #          default DAC volume
+    hv = dac.headphone_volume  #    default headphone analog volume
+    hg = dac.headphone_left_gain  # default headphone amp gain
+    sv = dac.speaker_volume  #      default speaker analog volume
+    sg = dac.speaker_gain  #        default speaker amp gain
+    note = 60
+    synth.press(note)
+
+    # Check for unbuffered keystroke input on the USB serial console
+    print("""
+=== TLV320DAC Volume Tester ===
+
+Controls:
+ q/z: dac_volume +/- 1
+ w/x: headphone_volume +/- 1
+ e/c: headphone_left_gain headphone_right_gain +/- 1
+ r/v: speaker_volume +/- 1
+ t/b: speaker_gain +/- 6
+ space: toggle speaker_output (amp power), this will reset volume & gain
+
+For less headphone noise, turn off the speaker amp (spacebar)
+""")
+    while True:
+        time.sleep(0.01)
+        if supervisor.runtime.serial_bytes_available:
+            while supervisor.runtime.serial_bytes_available:
+                c = sys.stdin.read(1)
+                if c == "q":
+                    # Q = DAC Volume UP
+                    dv = min(DV_MAX, max(DV_MIN, dv + 1))
+                    dac.dac_volume = dv
+                    print(f"dv = {dv:.1f} ({dac.dac_volume:.1f})")
+                elif c == "z":
+                    # Z = DAC Volume DOWN
+                    dv = min(DV_MAX, max(DV_MIN, dv - 1))
+                    dac.dac_volume = dv
+                    print(f"dv = {dv:.1f} ({dac.dac_volume:.1f})")
+                elif c == "w":
+                    # W = Headphone Volume UP
+                    hv = min(HV_MAX, max(HV_MIN, hv + 1))
+                    dac.headphone_volume = hv
+                    print(f"hv = {hv:.1f} ({dac.headphone_volume:.1f})")
+                elif c == "x":
+                    # X = Headphone Volume DOWN
+                    hv = min(HV_MAX, max(HV_MIN, hv - 1))
+                    dac.headphone_volume = hv
+                    print(f"hv = {hv:.1f} ({dac.headphone_volume:.1f})")
+                elif c == "e":
+                    # E = Headphone Amp Gain UP
+                    hg = min(HG_MAX, max(HG_MIN, hg + 1))
+                    dac.headphone_left_gain = hg
+                    dac.headphone_right_gain = hg
+                    print(f"hg = {hg:.1f} ({dac.headphone_left_gain})")
+                elif c == "c":
+                    # C = Headphone Amp Gain DOWN
+                    hg = min(HG_MAX, max(HG_MIN, hg - 1))
+                    dac.headphone_left_gain = hg
+                    dac.headphone_right_gain = hg
+                    print(f"hg = {hg:.1f} ({dac.headphone_left_gain})")
+
+                if c == "r":
+                    # R = Speaker Volume UP
+                    sv = min(SV_MAX, max(SV_MIN, sv + 1))
+                    dac.speaker_volume = sv
+                    print(f"sv = {sv:.1f} ({dac.speaker_volume:.1f})")
+                elif c == "v":
+                    # V = Speaker Volume DOWN
+                    sv = min(SV_MAX, max(SV_MIN, sv - 1))
+                    dac.speaker_volume = sv
+                    print(f"sv = {sv:.1f} ({dac.speaker_volume:.1f})")
+                elif c == "t":
+                    # T = Speaker Amp Gain UP
+                    sg = min(SG_MAX, max(SG_MIN, sg + SG_STEP))
+                    dac.speaker_gain = sg
+                    print(f"sg = {sg:.1f} ({dac.speaker_gain})")
+                elif c == "b":
+                    # B = Speaker Amp Gain DOWN
+                    sg = min(SG_MAX, max(SG_MIN, sg - SG_STEP))
+                    dac.speaker_gain = sg
+                    print(f"sg = {sg:.1f} ({dac.speaker_gain})")
+                elif c == " ":
+                    # Space = Toggle speaker amp enable/disable
+                    en = not dac.speaker_output
+                    dac.speaker_output = en
+                    print(f"speaker_output = {en}")
+
+
+main()


### PR DESCRIPTION
This PR is meant to deal with volume and gain setting problems for speakers and headphones, as discussed in [Volume setting properties don't work right # 9](https://github.com/adafruit/Adafruit_CircuitPython_TLV320/issues/9).

This makes several interrelated changes with the goals of:
1. Fix the broken analog volume control setters and getters to use Table 6-24 from the datasheet
2. Improve the documentation comments for properties related to volume, gain, and muting of the headphone and speaker signal chains.
3. Merge some of the setter and getter documentation comments to account for the fact that Sphinx totally ignores the comments on the setters when it renders the html docs. Anything important needs to go in the getter's comment.
4. Smooth out some rough edges in the API that would have made for really awkward documentation. In particular, the `speaker_gain` property used different data types for the setter and getter, and the setter was using undocumented constants.