### PR TITLE
fix broken "Volume test" example link in docs

### DIFF
--- a/adafruit_tlv320.py
+++ b/adafruit_tlv320.py
@@ -87,7 +87,7 @@ For this one, the default headphone output volume will be way too low for
 use with a device that expects consumer line level input (-10 dBV). To fix
 that, you can increase ``dac_volume`` or ``headphone_volume``. If you want
 to experiment with different ways of setting the levels, check out the
-volume test example: `Volume test <../examples.html#volume-test>`_
+volume test example: `Volume test <./examples.html#volume-test>`_
 
 ::
 


### PR DESCRIPTION
The relative link worked fine on my local server, but it gave me a 404 when I checked the production version on the RTD server. Hopefully this will fix it?

This is the broken link:
<img width="676" height="279" alt="broken-docs-link" src="https://github.com/user-attachments/assets/c577a945-4167-4701-bd7b-08a8a2227513" />
