### PR TITLE
increase default headphone volume a little

### DIFF
--- a/adafruit_tlv320.py
+++ b/adafruit_tlv320.py
@@ -102,7 +102,7 @@ volume test example: `Volume test <./examples.html#volume-test>`_
     # and dac_volume as the main volume control fader)
     #
     # CAUTION: This will be *way* too loud for earbuds, please be careful!
-    dac.headphone_volume = -15.5  # default is -51.8 dB
+    dac.headphone_volume = -15.5  # default is -30.1 dB
 
 API
 ---
@@ -2130,7 +2130,7 @@ class TLV320DAC3100:
         impedance earbuds:
 
         * dac_volume = -20
-        * headphone_volume = -51.8
+        * headphone_volume = -30.1
         * headphone_left_gain = headphone_right_gain = 0
 
         If you set this to False, the setter turns off the headphone amp.
@@ -2163,7 +2163,7 @@ class TLV320DAC3100:
             self._page1._configure_headphone_driver(
                 left_powered=True, right_powered=True, common=HP_COMMON_1_65V
             )
-            self.headphone_volume = -52.8
+            self.headphone_volume = -30.1
             # NOTE: If you use DAC_ROUTE_HP here instead of DAC_ROUTE_MIXER,
             # the DAC output will bypass the headphone analog volume
             # attenuation stage and go straight into the headphone amp. That


### PR DESCRIPTION
I think when I tested this in the prior volume PR I somehow crossed wires with one or more of the libraries on my device and was testing on a version that was louder than the real one. 

I've realized now using most up to date versions of all libraries that the default volume level chosen for headphones is a little too low I think. 

I tested using this demo script: https://github.com/adafruit/Adafruit_CircuitPython_FruitJam/blob/main/examples/fruitjam_synthio_speaker.py

With the current setting of -51.8 the tones on volumes 5 and 7 are in-audible to me using ear buds, and a pair of USB powered speakers. Volumes 10-12 I can hear, but are all very quiet. 

With the changed value from this PR -30.1 I can hear tones at all volume levels in the demo script. 5 is quiet and 12 getting close to loud, but not uncomfortable even with earbuds. 