### PR TITLE
raise default volume

### DIFF
--- a/adafruit_tlv320.py
+++ b/adafruit_tlv320.py
@@ -2158,12 +2158,12 @@ class TLV320DAC3100:
             self.right_dac_mute = False
             self.left_dac_path = DAC_PATH_NORMAL
             self.right_dac_path = DAC_PATH_NORMAL
-            self.headphone_left_gain = 0
-            self.headphone_right_gain = 0
+            self.headphone_left_gain = 6
+            self.headphone_right_gain = 6
             self._page1._configure_headphone_driver(
                 left_powered=True, right_powered=True, common=HP_COMMON_1_65V
             )
-            self.headphone_volume = -30.1
+            self.headphone_volume = -20.1
             # NOTE: If you use DAC_ROUTE_HP here instead of DAC_ROUTE_MIXER,
             # the DAC output will bypass the headphone analog volume
             # attenuation stage and go straight into the headphone amp. That
@@ -2213,12 +2213,12 @@ class TLV320DAC3100:
             self.right_dac_mute = False
             self.left_dac_path = DAC_PATH_NORMAL
             self.right_dac_path = DAC_PATH_NORMAL
-            self.speaker_gain = 6  # safest speaker amp gain option: 6 dB
+            self.speaker_gain = 12
             self._page1._set_speaker_enabled(True)
             self._page1._configure_analog_inputs(
                 left_dac=DAC_ROUTE_MIXER, right_dac=DAC_ROUTE_MIXER
             )
-            self.speaker_volume = -20.1
+            self.speaker_volume = -10
             self.speaker_mute = False
         else:
             self._page1._set_speaker_enabled(False)


### PR DESCRIPTION
After some further testing with different speakers and headphones with the boot animation and audio examples from https://github.com/adafruit/Adafruit_CircuitPython_FruitJam/tree/main/examples I'm thinking that the default volume is still a little low for most wav files. 

This bumps the default volume levels a little bit for both speaker and headphone. 

I tested the new values with boot animation and those audio examples on speakers, earbuds, and 3.5mm speakers. The JST Speaker is still a little quiet, but I'm hesitant to push it much further since it's such a tiny speaker.  With the changes from this PR, and this one from the fruit jam repo: https://github.com/adafruit/Adafruit_CircuitPython_FruitJam/pull/22 the JST speaker starts to become audible to my ear at around `0.5` volume using the 0.0 - 1.0 scale introduced by that fruit jam PR, below that I can either not hear anything, or can hear it very faintly if I put the fruit jam up to my ear.

